### PR TITLE
 Remove the details from the returned payload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Make a POST request with "Content-Type" : "application/json" to.
 
 https://govuk-content-quality-metrics.cloudapps.digital/metrics
 
+The posted body should have the format:
+
+```
+{"content": "the text content goes here. and another sentence"}
+```
+
 ## Testing
 
 Specs are written using mocha/chai/chaiHttp.

--- a/metrics/metrics-generator.js
+++ b/metrics/metrics-generator.js
@@ -18,7 +18,7 @@ const spell = require('retext-spell');
 const _ = require('lodash');
 
 function getName(name) {
-  return _.replace(name, 'retext-', '').replace('-', '_');
+  return _.replace(name, 'retext-', '').replace('-', '_') + '_count';
 }
 
 async function generate(text) {

--- a/metrics/metrics-generator.js
+++ b/metrics/metrics-generator.js
@@ -52,18 +52,7 @@ function transformResults(results) {
 }
 
 function createEntry(src) {
-  return {
-    messages: _.map(src, mapEntry),
-    count: src.length
-  };
-}
-
-function mapEntry(src) {
-  return {
-    actual: src.actual,
-    reason: src.message,
-    location: src.location
-  };
+  return src.length;
 }
 
 module.exports = generate;

--- a/metrics/metrics.spec.js
+++ b/metrics/metrics.spec.js
@@ -19,7 +19,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.readability).to.eq(1);
+    expect(res.body.readability_count).to.eq(1);
   });
   it('should check for passive voice', async () => {
     const res = await chai.request(server)
@@ -29,7 +29,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.passive).to.eq(2);
+    expect(res.body.passive_count).to.eq(2);
   });
   it('should check for spelling', async () => {
     const res = await chai.request(server)
@@ -39,7 +39,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.spell).to.eq(1);
+    expect(res.body.spell_count).to.eq(1);
   });
   it('should check for contractions', async () => {
     const res = await chai.request(server)
@@ -49,7 +49,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.contractions).to.eq(1);
+    expect(res.body.contractions_count).to.eq(1);
   });
   it('should check for indefinite article', async () => {
     const res = await chai.request(server)
@@ -59,7 +59,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.indefinite_article).to.eq(2);
+    expect(res.body.indefinite_article_count).to.eq(2);
   });
   it('should check for redundant acronymns', async () => {
     const res = await chai.request(server)
@@ -69,7 +69,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.redundant_acronyms).to.eq(1);
+    expect(res.body.redundant_acronyms_count).to.eq(1);
   });
   it('should check for profanities', async () => {
     const res = await chai.request(server)
@@ -79,7 +79,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.profanities).to.eq(1);
+    expect(res.body.profanities_count).to.eq(1);
   });
   it('should check for equality', async () => {
     const res = await chai.request(server)
@@ -89,7 +89,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.equality).to.eq(1);
+    expect(res.body.equality_count).to.eq(1);
   });
   it('should check for repeated words', async () => {
     const res = await chai.request(server)
@@ -99,7 +99,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.repeated_words).to.eq(1);
+    expect(res.body.repeated_words_count).to.eq(1);
   });
   it('should check for simpler alternatives', async () => {
     const res = await chai.request(server)
@@ -109,6 +109,6 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.simplify).to.eq(1);
+    expect(res.body.simplify_count).to.eq(1);
   });
 });

--- a/metrics/metrics.spec.js
+++ b/metrics/metrics.spec.js
@@ -19,26 +19,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.readability).to
-      .deep.eq({
-        messages: [{
-          reason: 'Hard to read sentence (confidence: 6/7)',
-          location: {
-            end: {
-              column: 87,
-              line: 1,
-              offset: 86
-            },
-            start: {
-              column: 1,
-              line: 1,
-              offset: 0
-            }
-          },
-          actual: 'Formula to detect the grade level of text according to the Flesch–Kincaid Grade Level.'
-        }],
-        count: 1
-      });
+    expect(res.body.readability).to.eq(1);
   });
   it('should check for passive voice', async () => {
     const res = await chai.request(server)
@@ -48,42 +29,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.passive).to
-      .deep.eq({
-        messages: [{
-          actual: 'withheld',
-          reason: 'Don’t use the passive voice',
-          location: {
-            start: {
-              line: 1,
-              column: 8,
-              offset: 7
-            },
-            end: {
-              line: 1,
-              column: 16,
-              offset: 15
-            }
-          }
-        },
-        {
-          actual: 'fed',
-          reason: 'Don’t use the passive voice',
-          location: {
-            start: {
-              line: 1,
-              column: 37,
-              offset: 36
-            },
-            end: {
-              line: 1,
-              column: 40,
-              offset: 39
-            }
-          }
-        }],
-        count: 2
-      });
+    expect(res.body.passive).to.eq(2);
   });
   it('should check for spelling', async () => {
     const res = await chai.request(server)
@@ -93,26 +39,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.spell).to
-      .deep.eq({
-        messages: [{
-          actual: 'Somethng',
-          reason: '`Somethng` is misspelt; did you mean `Something`?',
-          location: {
-            start: {
-              line: 1,
-              column: 1,
-              offset: 0
-            },
-            end: {
-              line: 1,
-              column: 9,
-              offset: 8
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.spell).to.eq(1);
   });
   it('should check for contractions', async () => {
     const res = await chai.request(server)
@@ -122,26 +49,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.contractions).to
-      .deep.eq({
-        messages: [{
-          actual: 'isnt',
-          reason: 'Expected an apostrophe in `isnt`, like this: `isn’t`',
-          location: {
-            start: {
-              line: 1,
-              column: 11,
-              offset: 10
-            },
-            end: {
-              line: 1,
-              column: 15,
-              offset: 14
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.contractions).to.eq(1);
   });
   it('should check for indefinite article', async () => {
     const res = await chai.request(server)
@@ -151,42 +59,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.indefinite_article).to
-      .deep.eq({
-        messages: [{
-          actual: 'a',
-          reason: 'Use `an` before `8-year`, not `a`',
-          location: {
-            start: {
-              line: 1,
-              column: 12,
-              offset: 11
-            },
-            end: {
-              line: 1,
-              column: 13,
-              offset: 12
-            }
-          }
-        },
-        {
-          actual: 'a',
-          reason: 'Use `an` before `hour`, not `a`',
-          location: {
-            start: {
-              line: 1,
-              column: 50,
-              offset: 49
-            },
-            end: {
-              line: 1,
-              column: 51,
-              offset: 50
-            }
-          }
-        }],
-        count: 2
-      });
+    expect(res.body.indefinite_article).to.eq(2);
   });
   it('should check for redundant acronymns', async () => {
     const res = await chai.request(server)
@@ -196,26 +69,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.redundant_acronyms).to
-      .deep.eq({
-        messages: [{
-          actual: 'ATM machine',
-          reason: 'Replace `ATM machine` with `ATM`',
-          location: {
-            start: {
-              line: 1,
-              column: 21,
-              offset: 20
-            },
-            end: {
-              line: 1,
-              column: 32,
-              offset: 31
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.redundant_acronyms).to.eq(1);
   });
   it('should check for profanities', async () => {
     const res = await chai.request(server)
@@ -225,26 +79,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.profanities).to
-      .deep.eq({
-        messages: [{
-          actual: 'arse',
-          reason: 'Don’t use “arse”, it’s profane',
-          location: {
-            start: {
-              line: 1,
-              column: 18,
-              offset: 17
-            },
-            end: {
-              line: 1,
-              column: 22,
-              offset: 21
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.profanities).to.eq(1);
   });
   it('should check for equality', async () => {
     const res = await chai.request(server)
@@ -254,25 +89,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.equality).to
-      .deep.eq({
-        messages: [{
-          reason: '`his` may be insensitive, use `their`, `theirs`, `them` instead',
-          location: {
-            start: {
-              line: 1,
-              column: 15,
-              offset: 14
-            },
-            end: {
-              line: 1,
-              column: 18,
-              offset: 17
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.equality).to.eq(1);
   });
   it('should check for repeated words', async () => {
     const res = await chai.request(server)
@@ -282,26 +99,7 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.repeated_words).to
-      .deep.eq({
-        messages: [{
-          actual: 'want ',
-          reason: 'Expected `want` once, not twice',
-          location: {
-            start: {
-              line: 1,
-              column: 10,
-              offset: 9
-            },
-            end: {
-              line: 1,
-              column: 19,
-              offset: 18
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.repeated_words).to.eq(1);
   });
   it('should check for simpler alternatives', async () => {
     const res = await chai.request(server)
@@ -311,25 +109,6 @@ describe('Metrics', () => {
       });
     expect(res).to.have.status(200);
     expect(res).to.be.json;
-    expect(res.body.simplify).to
-      .deep.eq({
-        messages: [{
-          actual: 'utilise',
-          reason: 'Replace “utilise” with “use”',
-          location: {
-            start: {
-              line: 1,
-              column: 9,
-              offset: 8
-            },
-            end: {
-              line: 1,
-              column: 16,
-              offset: 15
-            }
-          }
-        }],
-        count: 1
-      });
+    expect(res.body.simplify).to.eq(1);
   });
 });


### PR DESCRIPTION
We have been getting a Payload Too Large error when
posting a large amount of text to the quality metrics
service.

This is due to returning the details of each quality error
in the response. We don't make use of this level of detail.

This PR removes the 'messages' array from the response
so the response is now in the following format:

{
  "readability_count": 2,
  "passive_count": 1,
  "repeated_words_count": 3,
  and so on...
}

Trello: [Quality Service: Payload too large error](https://trello.com/c/yjkmaISV/459-quality-service-payload-too-large-error)

There is a [related PR in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/792)