### PR TITLE
Return zero where no retext output

### DIFF
--- a/metrics/metrics-generator.js
+++ b/metrics/metrics-generator.js
@@ -1,7 +1,9 @@
+
 const Promise = require('bluebird');
 
 // eslint-disable-next-line no-use-extend-native/no-use-extend-native
 const retext = Promise.promisifyAll(require('retext'));
+/* eslint camelcase: ["error", {properties: "never"}] */
 
 const contractions = require('retext-contractions');
 const dictionary = require('dictionary-en-gb');
@@ -45,10 +47,22 @@ async function generate(text) {
 }
 
 function transformResults(results) {
-  return _.chain(results.messages)
+  const newValues = _.chain(results.messages)
     .groupBy(res => getName(res.source))
     .mapValues(createEntry)
     .value();
+  return _.assign({
+    readability_count: 0,
+    equality_count: 0,
+    indefinite_article_count: 0,
+    passive_count: 0,
+    profanities_count: 0,
+    redundant_acronyms_count: 0,
+    repeated_words_count: 0,
+    spell_count: 0,
+    contractions_count: 0,
+    simplify_count: 0
+  }, newValues);
 }
 
 function createEntry(src) {

--- a/metrics/metrics.spec.js
+++ b/metrics/metrics.spec.js
@@ -20,6 +20,15 @@ describe('Metrics', () => {
     expect(res).to.have.status(200);
     expect(res).to.be.json;
     expect(res.body.readability_count).to.eq(1);
+    // Check for default values if no issues
+    expect(res.body.passive_count).to.eq(0);
+    expect(res.body.profanities_count).to.eq(0);
+    expect(res.body.repeated_words_count).to.eq(0);
+    expect(res.body.indefinite_article_count).to.eq(0);
+    expect(res.body.redundant_acronyms_count).to.eq(0);
+    expect(res.body.equality_count).to.eq(0);
+    expect(res.body.contractions_count).to.eq(0);
+    expect(res.body.simplify_count).to.eq(0);
   });
   it('should check for passive voice', async () => {
     const res = await chai.request(server)
@@ -30,6 +39,8 @@ describe('Metrics', () => {
     expect(res).to.have.status(200);
     expect(res).to.be.json;
     expect(res.body.passive_count).to.eq(2);
+    // Check for default values if no issues
+    expect(res.body.spell_count).to.eq(0);
   });
   it('should check for spelling', async () => {
     const res = await chai.request(server)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "POST the content to /metrics and get back a list of quality errors",
   "engines": {
-    "node": "8.9.3"
+    "node": "8.11.2"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously were were only returning numbers where
retext produced some output.

Now we return a number for all quality metrics,
returning zero where there is no output from
retext.

Trello: [Create Sidekiq job to make processing Quality Metrics more reliable](https://trello.com/c/ONjimA9e/525-5-create-sidekiq-job-to-make-processing-quality-metrics-more-reliable)

There is a [related PR in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/801)