### PR TITLE
Increase the bodyParser limit to 50mb

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ const bodyParser = require('body-parser');
 const metrics = require('./metrics/metrics');
 
 const app = express()
-  .use(bodyParser.json())
+  .use(bodyParser.json({limit: '50mb'}))
   .use('/', metrics);
 
 module.exports = app;


### PR DESCRIPTION
We have been experiencing 'Payload too large' errors from
this service.

The previous attempt to fix this reduced the size of the returned
payload. This was not the problem. The problem was, in reality,
the size of the request payload, which defaults to 100k.

We have now increased this to 50mb.